### PR TITLE
Parquet: Add Variant type support in Parquet module

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -19,14 +19,17 @@
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
+import java.util.Set;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializableFunction;
 
 class Identity<T> implements Transform<T, T> {
+  private static Set<Type> UNSUPPORTED_TYPES = Set.of(Types.VariantType.get());
   private static final Identity<?> INSTANCE = new Identity<>();
 
   private final Type type;
@@ -38,8 +41,7 @@ class Identity<T> implements Transform<T, T> {
    */
   @Deprecated
   public static <I> Identity<I> get(Type type) {
-    Preconditions.checkArgument(
-        type.typeId() != Type.TypeID.VARIANT, "Unsupported type for identity: %s", type);
+    Preconditions.checkArgument(!UNSUPPORTED_TYPES.contains(type), "Unsupported type for identity: %s", type);
 
     return new Identity<>(type);
   }

--- a/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
@@ -125,6 +125,11 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   }
 
   @Override
+  public Type variant() {
+    return Types.VariantType.get();
+  }
+
+  @Override
   public Type primitive(Type.PrimitiveType primitive) {
     return primitive;
   }

--- a/api/src/main/java/org/apache/iceberg/types/Type.java
+++ b/api/src/main/java/org/apache/iceberg/types/Type.java
@@ -97,6 +97,10 @@ public interface Type extends Serializable {
     return false;
   }
 
+  default boolean isVariantType() {
+    return false;
+  }
+
   default NestedType asNestedType() {
     throw new IllegalArgumentException("Not a nested type: " + this);
   }

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -709,6 +709,10 @@ public class TypeUtil {
       return null;
     }
 
+    public T variant() {
+      return null;
+    }
+
     public T primitive(Type.PrimitiveType primitive) {
       return null;
     }
@@ -784,6 +788,9 @@ public class TypeUtil {
             map,
             new VisitFuture<>(map.keyType(), visitor),
             new VisitFuture<>(map.valueType(), visitor));
+
+      case VARIANT:
+        return visitor.variant();
 
       default:
         return visitor.primitive(type.asPrimitiveType());

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -430,6 +430,11 @@ public class Types {
     }
 
     @Override
+    public boolean isVariantType() {
+      return true;
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -118,6 +118,12 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
   }
 
   @Override
+  public VectorizedReader<?> variant(GroupType variant) {
+    throw new UnsupportedOperationException(
+        "Vectorized reads are not supported yet for variant fields");
+  }
+
+  @Override
   public VectorizedReader<?> primitive(
       org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
 

--- a/build.gradle
+++ b/build.gradle
@@ -793,6 +793,8 @@ project(':iceberg-parquet') {
       exclude group: 'org.apache.avro', module: 'avro'
     }
 
+    implementation 'org.apache.spark:spark-variant_2.13:4.0.0-preview1'
+
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
   }

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -25,6 +25,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -42,6 +43,7 @@ public class SchemaParser {
   private static final String STRUCT = "struct";
   private static final String LIST = "list";
   private static final String MAP = "map";
+  private static final String VARIANT = "variant";
   private static final String FIELDS = "fields";
   private static final String ELEMENT = "element";
   private static final String KEY = "key";
@@ -132,6 +134,8 @@ public class SchemaParser {
   static void toJson(Type type, JsonGenerator generator) throws IOException {
     if (type.isPrimitiveType()) {
       toJson(type.asPrimitiveType(), generator);
+    } else if (type.isVariantType()) {
+      generator.writeString(type.toString());
     } else {
       Type.NestedType nested = type.asNestedType();
       switch (type.typeId()) {
@@ -166,6 +170,10 @@ public class SchemaParser {
 
   private static Type typeFromJson(JsonNode json) {
     if (json.isTextual()) {
+      if (VARIANT.equals(json.asText().toLowerCase(Locale.ROOT))) {
+        return Types.VariantType.get();
+      }
+
       return Types.fromPrimitiveString(json.asText());
     } else if (json.isObject()) {
       JsonNode typeObj = json.get(TYPE);

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -56,6 +56,10 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
   @Override
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public Schema record(Schema record, List<String> names, Iterable<Schema.Field> schemaIterable) {
+    if (current.isVariantType()) {
+      return variant(record);
+    }
+
     Preconditions.checkArgument(
         current.isNestedType() && current.asNestedType().isStructType(),
         "Cannot project non-struct: %s",
@@ -126,6 +130,17 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
     if (hasChange || renames.containsKey(record.getFullName())) {
       return AvroSchemaUtil.copyRecord(record, updatedFields, renames.get(record.getFullName()));
     }
+
+    return record;
+  }
+
+  public Schema variant(Schema record) {
+    Preconditions.checkArgument(
+        current.isVariantType()
+            && record.getField("value") != null
+            && record.getField("metadata") != null,
+        "Expect variant type with value and metadata fields: %s",
+        current);
 
     return record;
   }

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -49,6 +49,15 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   private static final Schema UUID_SCHEMA =
       LogicalTypes.uuid().addToSchema(Schema.createFixed("uuid_fixed", null, null, 16));
   private static final Schema BINARY_SCHEMA = Schema.create(Schema.Type.BYTES);
+  private static final Schema VARIANT_SCHEMA =
+      Schema.createRecord(
+          "variant",
+          null,
+          null,
+          false,
+          List.of(
+              new Schema.Field("value", BINARY_SCHEMA),
+              new Schema.Field("metadata", BINARY_SCHEMA)));
 
   static {
     TIMESTAMP_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
@@ -185,6 +194,11 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
     cacheSchema(map, mapSchema);
 
     return mapSchema;
+  }
+
+  @Override
+  public Schema variant() {
+    return VARIANT_SCHEMA;
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -76,6 +76,9 @@ public abstract class BaseParquetReaders<T> {
   protected abstract ParquetValueReader<T> createStructReader(
       List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
 
+  protected abstract ParquetValueReader<T> createVariantReader(
+      List<ParquetValueReader<?>> fieldReaders);
+
   private class FallbackReadBuilder extends ReadBuilder {
     private FallbackReadBuilder(MessageType type, Map<Integer, ?> idToConstant) {
       super(type, idToConstant);
@@ -390,6 +393,30 @@ public abstract class BaseParquetReaders<T> {
         default:
           throw new UnsupportedOperationException("Unsupported type: " + primitive);
       }
+    }
+
+    @Override
+    public ParquetValueReader<?> variant(GroupType variant) {
+      return createVariantReader(
+          List.of(
+              new ParquetValueReaders.ByteArrayReader(
+                  new ColumnDescriptor(
+                      new String[] {variant.getName(), "value"},
+                      new PrimitiveType(
+                          Type.Repetition.REQUIRED,
+                          PrimitiveType.PrimitiveTypeName.BINARY,
+                          "value"),
+                      0,
+                      0)),
+              new ParquetValueReaders.ByteArrayReader(
+                  new ColumnDescriptor(
+                      new String[] {variant.getName(), "metadata"},
+                      new PrimitiveType(
+                          Type.Repetition.REQUIRED,
+                          PrimitiveType.PrimitiveTypeName.BINARY,
+                          "metadata"),
+                      0,
+                      0))));
     }
 
     MessageType type() {

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders.StructReader;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
 public class GenericParquetReaders extends BaseParquetReaders<Record> {
@@ -49,6 +50,12 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
   protected ParquetValueReader<Record> createStructReader(
       List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
     return new RecordReader(types, fieldReaders, structType);
+  }
+
+  @Override
+  protected ParquetValueReader<Record> createVariantReader(
+      List<ParquetValueReader<?>> fieldReaders) {
+    return new VariantReader(fieldReaders);
   }
 
   private static class RecordReader extends StructReader<Record, Record> {
@@ -84,6 +91,28 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
     @Override
     protected void set(Record struct, int pos, Object value) {
       struct.set(pos, value);
+    }
+  }
+
+  /**
+   * Variant reader to read Value and Metadata binaries from Parquet file and convert to a record.
+   */
+  public static class VariantReader extends RecordReader {
+    private static final List<Type> types =
+        List.of(
+            new PrimitiveType(
+                Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.BINARY, "value"),
+            new PrimitiveType(
+                Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.BINARY, "metadata"));
+
+    VariantReader(List<ParquetValueReader<?>> readers) {
+      super(types, readers, null);
+    }
+
+    @Override
+    protected Record buildStruct(Record struct) {
+      // struct is of Value + Metadata binaries
+      return struct;
     }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -146,6 +146,11 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
   }
 
   @Override
+  public Type variant(GroupType variant) {
+    return Types.VariantType.get();
+  }
+
+  @Override
   public Type primitive(PrimitiveType primitive) {
     // first, use the logical type annotation, if present
     LogicalTypeAnnotation logicalType = primitive.getLogicalTypeAnnotation();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -144,7 +144,7 @@ public class ParquetSchemaUtil {
     @Override
     public Boolean struct(GroupType struct, List<Boolean> hasIds) {
       for (Boolean hasId : hasIds) {
-        if (hasId) {
+        if (hasId != null && hasId) {
           return true;
         }
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeVisitor.java
@@ -54,6 +54,14 @@ public class ParquetTypeVisitor<T> {
         }
       }
 
+      // TODO hack before Variant logical type is available in Parquet
+      if (
+      /*variant*/ annotation == null
+          && group.getFieldName(0).equals("value")
+          && group.getFieldName(1).equals("metadata")) {
+        return visitor.variant(group);
+      }
+
       return visitor.struct(group, visitFields(group, visitor));
     }
   }
@@ -201,6 +209,10 @@ public class ParquetTypeVisitor<T> {
   }
 
   public T map(GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T variant(GroupType variant) {
     return null;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariant.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariant.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.ZoneId;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.types.variant.Variant;
+import org.apache.spark.types.variant.VariantBuilder;
+
+public class ParquetVariant {
+  private Variant internalVariant;
+
+  public static ParquetVariant parseJson(String json) throws IOException {
+    return new ParquetVariant(VariantBuilder.parseJson(json));
+  }
+
+  public static ParquetVariant of(ByteBuffer value, ByteBuffer metadata) {
+    return new ParquetVariant(new Variant(value.array(), metadata.array()));
+  }
+
+  public static ParquetVariant toVariant(Type.PrimitiveType type, Object value) {
+    VariantBuilder builder = new VariantBuilder();
+    if (value == null) {
+      builder.appendNull();
+    } else {
+      if (type instanceof Types.BooleanType) {
+        builder.appendBoolean((boolean) value);
+      } else if (type instanceof Types.IntegerType) {
+        builder.appendLong((int) value);
+      } else if (type instanceof Types.LongType) {
+        builder.appendLong((long) value);
+      } else if (type instanceof Types.FloatType) {
+        builder.appendFloat((float) value);
+      } else if (type instanceof Types.DoubleType) {
+        builder.appendDouble((double) value);
+      } else if (type instanceof Types.StringType) {
+        builder.appendString((String) value);
+      } else if (type instanceof Types.BinaryType || type instanceof Types.FixedType) {
+        builder.appendBinary((byte[]) value);
+      } else if (type instanceof Types.DecimalType) {
+        builder.appendDecimal((BigDecimal) value);
+      } else if (type instanceof Types.TimestampType) {
+        if (((Types.TimestampType) type).shouldAdjustToUTC()) {
+          builder.appendTimestamp((long) value);
+        } else {
+          builder.appendTimestampNtz((long) value);
+        }
+      } else if (type instanceof Types.DateType) {
+        builder.appendDate((int) value);
+      } else if (type instanceof Types.TimeType
+          || type instanceof Types.TimestampNanoType
+          || type instanceof Types.UUIDType) {
+        throw new UnsupportedOperationException("Unsupported type in variant: " + type);
+      }
+    }
+
+    return new ParquetVariant(builder.result());
+  }
+
+  private ParquetVariant(Variant internalVariant) {
+    this.internalVariant = internalVariant;
+  }
+
+  public byte[] getValue() {
+    return internalVariant.getValue();
+  }
+
+  public byte[] getMetadata() {
+    return internalVariant.getMetadata();
+  }
+
+  public String toJson(ZoneId zoneId) {
+    return internalVariant.toJson(zoneId);
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -77,6 +77,19 @@ public class TypeToMessageType {
     return builder.id(id).named(AvroSchemaUtil.makeCompatibleName(name));
   }
 
+  public GroupType variant(Type.Repetition repetition, int id, String name) {
+    Types.GroupBuilder<GroupType> builder = Types.buildGroup(repetition);
+
+    return builder
+        .addField(
+            new org.apache.parquet.schema.PrimitiveType(Type.Repetition.REQUIRED, BINARY, "value"))
+        .addField(
+            new org.apache.parquet.schema.PrimitiveType(
+                Type.Repetition.REQUIRED, BINARY, "metadata"))
+        .id(id)
+        .named(AvroSchemaUtil.makeCompatibleName(name));
+  }
+
   public Type field(NestedField field) {
     Type.Repetition repetition =
         field.isOptional() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;
@@ -85,7 +98,8 @@ public class TypeToMessageType {
 
     if (field.type().isPrimitiveType()) {
       return primitive(field.type().asPrimitiveType(), repetition, id, name);
-
+    } else if (field.type().isVariantType()) {
+      return variant(repetition, id, name);
     } else {
       NestedType nested = field.type().asNestedType();
       if (nested.isStructType()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -144,6 +144,11 @@ public class TypeWithSchemaVisitor<T> {
         }
       }
 
+      if (iType instanceof Types.VariantType) {
+        // Handle Variant type
+        return visitor.variant(group);
+      }
+
       Types.StructType struct = iType != null ? iType.asStructType() : null;
       return visitor.struct(struct, group, visitFields(struct, group, visitor));
     }
@@ -214,6 +219,10 @@ public class TypeWithSchemaVisitor<T> {
   }
 
   public T map(Types.MapType iMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T variant(GroupType variant) {
     return null;
   }
 


### PR DESCRIPTION
This is to enable writing Variant data to Parquet file and read from Parquet file in the format of struct of metadata and data. 

This PR adds:
- A Parquet Variant implementation which currently uses Spark-Variant library as the dependency. We can reimplement inside the Iceberg-Parquet library to remove such dependency for now before that is moved to Parquet project.
- Add the Variant support in Parquet reader/writer.

Fix: #11178.